### PR TITLE
Thread `style` object down from TextEditorLeaf to TextEditorTextNode

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@twitter-forks/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.5-twitter-forks.4",
+  "version": "0.10.5-twitter-forks.2",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@twitter-forks/draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.5-twitter-forks.2",
+  "version": "0.10.5-twitter-forks.4",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -169,7 +169,7 @@ class DraftEditorLeaf extends React.Component<Props> {
         data-offset-key={offsetKey}
         ref={ref => (this.leaf = ref)}
         style={styleObj}>
-        <DraftEditorTextNode>{text}</DraftEditorTextNode>
+        <DraftEditorTextNode style={this.props.style}>{text}</DraftEditorTextNode>
       </span>
     );
   }

--- a/src/component/contents/DraftEditorLeaf.react.js
+++ b/src/component/contents/DraftEditorLeaf.react.js
@@ -49,6 +49,9 @@ type Props = {
   // The offset of this string within its block.
   start: number,
 
+  // The style directly applied to DraftEdiorLeaf, usually from decorator
+  style?: Object,
+
   // The set of style(s) names to apply to the node.
   styleSet: DraftInlineStyle,
 

--- a/src/component/contents/DraftEditorTextNode.react.js
+++ b/src/component/contents/DraftEditorTextNode.react.js
@@ -102,7 +102,7 @@ class DraftEditorTextNode extends React.Component<Props> {
     }
 
     const additionalProps = {};
-    if (this.props.style === 'object') {
+    if (typeof this.props.style === 'object') {
       additionalProps.style = this.props.style;
     }
     return (

--- a/src/component/contents/DraftEditorTextNode.react.js
+++ b/src/component/contents/DraftEditorTextNode.react.js
@@ -100,8 +100,13 @@ class DraftEditorTextNode extends React.Component<Props> {
     if (this.props.children === '') {
       return this._forceFlag ? NEWLINE_A : NEWLINE_B;
     }
+
+    const additionalProps = {};
+    if (this.props.style === 'object') {
+      additionalProps.style = this.props.style;
+    }
     return (
-      <span key={this._forceFlag ? 'A' : 'B'} data-text="true">
+      <span key={this._forceFlag ? 'A' : 'B'} data-text="true" {...additionalProps}>
         {this.props.children}
       </span>
     );

--- a/src/component/handlers/drag/DraftEditorDragHandler.js
+++ b/src/component/handlers/drag/DraftEditorDragHandler.js
@@ -125,6 +125,14 @@ var DraftEditorDragHandler = {
       insertTextAtSelection(editorState, dropSelection, data.getText()),
     );
   },
+
+  /**
+   * Edge disallows drag event by default (A No Symbol (⃠) will be shown on the dragged image by default).
+   * Without preventing the default dragOver handler a drop event can not be triggered.
+   */
+  onDragOver: function onDragOver(editor: DraftEditor, e: Object): void {
+    e.preventDefault();
+  },
 };
 
 function moveText(


### PR DESCRIPTION
Thread `style` object down from TextEditorLeaf to TextEditorTextNode

Problem
=======
Currently, entity styling are done by wrapping TextEditorLeaf with styled wrapper. For example, in draft-js's `tweet` example, mentions are applied with different color by wrapping a <span> around {this.props.children} (which is a TextEditorLeaf):
https://github.com/facebook/draft-js/blob/master/examples/draft-0-10-0/tweet/tweet.html#L106
    
 However, occasionally, we want to style the TextEditorTextNode (rendered by TextEditorLeaf) directly, just like the the `applyInlineStyle`.
    
Solution
=======
This patch thread `style` object down from TextEditorLeaf to TextEditorTextNode, so that decorator can style TextEditorTextNode directly. This can be achieved by adding props to {this.props.children} using React.cloneElement, for example:

```
const entitySpan = props => {
  const { children, contentState, entityKey } = props;

  const styledChildren =  React.Children.map(children, child =>
       React.cloneElement(child, { style: {...}})
   )

  return styledChildren;
};
```