### PR TITLE
Fix drag and drop in Edge

### DIFF
--- a/src/component/handlers/drag/DraftEditorDragHandler.js
+++ b/src/component/handlers/drag/DraftEditorDragHandler.js
@@ -125,6 +125,14 @@ var DraftEditorDragHandler = {
       insertTextAtSelection(editorState, dropSelection, data.getText()),
     );
   },
+
+  /**
+   * Edge disallows drag event by default (A No Symbol (⃠) will be shown on the dragged image by default).
+   * Without preventing the default dragOver handler a drop event can not be triggered.
+   */
+  onDragOver: function onDragOver(editor: DraftEditor, e: Object): void {
+    e.preventDefault();
+  },
 };
 
 function moveText(


### PR DESCRIPTION
Problem
=======
Edge disallows drag event by default (A No Symbol (⃠) will be shown on the dragged image by default).. Drop event is not triggered.

Solution
========
Prevent the default handler of dragOver event would make the drop event go through.
The underlying hypothesis is somehow in Edge, the default handler of dragOver affects drop event (Note draft-js already calls `e.preventDefault` in `onDrop`).
