### PR TITLE
Allow custom attributes to be added to draft editor content

### DIFF
--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -140,6 +140,7 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
     blockRenderMap: DefaultDraftBlockRenderMap,
     blockRendererFn: emptyFunction.thatReturnsNull,
     blockStyleFn: emptyFunction.thatReturns(''),
+    customeProps: {},
     keyBindingFn: getDefaultKeyBinding,
     readOnly: false,
     spellCheck: false,
@@ -411,7 +412,8 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
             spellCheck={allowSpellCheck && this.props.spellCheck}
             style={contentStyle}
             suppressContentEditableWarning
-            tabIndex={this.props.tabIndex}>
+            tabIndex={this.props.tabIndex}
+            {...this.props.customProps}>
             {/*
               Needs to come earlier in the tree as a sibling (not ancestor) of
               all DraftEditorLeaf nodes so it's first in postorder traversal.

--- a/src/component/base/DraftEditor.react.js
+++ b/src/component/base/DraftEditor.react.js
@@ -140,7 +140,7 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
     blockRenderMap: DefaultDraftBlockRenderMap,
     blockRendererFn: emptyFunction.thatReturnsNull,
     blockStyleFn: emptyFunction.thatReturns(''),
-    customeProps: {},
+    customAttrs: {},
     keyBindingFn: getDefaultKeyBinding,
     readOnly: false,
     spellCheck: false,
@@ -413,7 +413,7 @@ class DraftEditor extends React.Component<DraftEditorProps, State> {
             style={contentStyle}
             suppressContentEditableWarning
             tabIndex={this.props.tabIndex}
-            {...this.props.customProps}>
+            {...this.props.customAttrs}>
             {/*
               Needs to come earlier in the tree as a sibling (not ancestor) of
               all DraftEditorLeaf nodes so it's first in postorder traversal.

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -178,14 +178,14 @@ export type DraftEditorProps = {
   // is used for both rendering and paste processing.
   blockRenderMap: DraftBlockRenderMap,
 
-  customProps?: Object,
+  customAttrs?: Object,
 };
 
 export type DraftEditorDefaultProps = {
   blockRenderMap: DraftBlockRenderMap,
   blockRendererFn: (block: BlockNodeRecord) => ?Object,
   blockStyleFn: (block: BlockNodeRecord) => string,
-  customProps: Object,
+  customAttrs: Object,
   keyBindingFn: (e: SyntheticKeyboardEvent<>) => ?string,
   readOnly: boolean,
   spellCheck: boolean,

--- a/src/component/base/DraftEditorProps.js
+++ b/src/component/base/DraftEditorProps.js
@@ -177,12 +177,15 @@ export type DraftEditorProps = {
   // an element tag and an optional react element wrapper. This configuration
   // is used for both rendering and paste processing.
   blockRenderMap: DraftBlockRenderMap,
+
+  customProps?: Object,
 };
 
 export type DraftEditorDefaultProps = {
   blockRenderMap: DraftBlockRenderMap,
   blockRendererFn: (block: BlockNodeRecord) => ?Object,
   blockStyleFn: (block: BlockNodeRecord) => string,
+  customProps: Object,
   keyBindingFn: (e: SyntheticKeyboardEvent<>) => ?string,
   readOnly: boolean,
   spellCheck: boolean,


### PR DESCRIPTION
Allow custom attributes to be added to draft editor content

Problem
======
Some tools need to interact with Draft-js based on HTML attributes. 

Solution
======
Allows a `customAttrs` object to be specified as <Editor />'s prop. The content of the object are set as attributes on DraftEditor content div.