### PR TITLE
Use \n rather than <br> in Edge for newline detection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.5-twitter-forks.9",
+  "version": "0.10.5-twitter-forks.10",
   "keywords": [
     "draftjs",
     "editor",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.10.5-twitter-forks.10",
+  "version": "0.10.5-twitter-forks.9",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/component/contents/DraftEditorTextNode.react.js
+++ b/src/component/contents/DraftEditorTextNode.react.js
@@ -18,9 +18,16 @@ const UserAgent = require('UserAgent');
 
 const invariant = require('invariant');
 
-// In IE, spans with <br> tags render as two newlines. By rendering a span
-// with only a newline character, we can be sure to render a single line.
-const useNewlineChar = UserAgent.isBrowser('IE <= 11');
+/**
+ * In IE, spans with <br> tags render as two newlines. By rendering a span
+ * with only a newline character, we can be sure to render a single line.
+ *
+ * In addition, Windows 10's touch keyboard (enabled in Tablet mode)
+ * will delete <br> in a span when swipe feature is used (similar to swype), which causes
+ * corrupt state. Given swipe feature only seem to be enabled in Edge, fallback to use
+ * new line character in Edge as well.
+ */
+ const useNewlineChar = UserAgent.isBrowser('IE <= 11') || UserAgent.isBrowser('Edge');
 
 /**
  * Check whether the node should be considered a newline.

--- a/src/component/contents/DraftEditorTextNode.react.js
+++ b/src/component/contents/DraftEditorTextNode.react.js
@@ -22,10 +22,10 @@ const invariant = require('invariant');
  * In IE, spans with <br> tags render as two newlines. By rendering a span
  * with only a newline character, we can be sure to render a single line.
  *
- * In addition, Windows 10's touch keyboard (enabled in Tablet mode)
- * deletes <br> in the span when swipe feature is used (similar to swype), which causes
- * corrupt state. Given swipe feature only seem to be enabled in Edge, fallback to use
- * new line character in Edge as well.
+ * In addition, Edge deletes the <br> when typing in a span with just <br> in it.
+ * However because <br> is only rendered on empty line (see `render()`), after typing React
+ * would tries to remove the <br> tag, which may already been removed by Edge.
+ * This causes the render to fail. Fall back to \n on Edge as well, for this reason.
  */
  const useNewlineChar = UserAgent.isBrowser('IE <= 11') || UserAgent.isBrowser('Edge');
 

--- a/src/component/contents/DraftEditorTextNode.react.js
+++ b/src/component/contents/DraftEditorTextNode.react.js
@@ -23,7 +23,7 @@ const invariant = require('invariant');
  * with only a newline character, we can be sure to render a single line.
  *
  * In addition, Windows 10's touch keyboard (enabled in Tablet mode)
- * will delete <br> in a span when swipe feature is used (similar to swype), which causes
+ * deletes <br> in the span when swipe feature is used (similar to swype), which causes
  * corrupt state. Given swipe feature only seem to be enabled in Edge, fallback to use
  * new line character in Edge as well.
  */


### PR DESCRIPTION
Use \n rather than < br > in Edge for newline detection

Draft.js uses a <br> on most browsers to represent a new line. However, Windows 10's touch keyboard (enabled in Tablet mode) deletes the <br> in the span when swipe feature is used (the feature is similar to swype - draw lines on keyboard to enter words), which causes corrupt state.

Given swipe feature only seem to be enabled in Edge, fallback to use new line character (\n) just like what's being done on IE. 