### PR TITLE
Fix CJK IME bug under Edge(Blink)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "draft-js",
   "description": "A React framework for building text editors.",
-  "version": "0.11.6-twitter-forks.1",
+  "version": "0.11.6-twitter-forks.3",
   "keywords": [
     "draftjs",
     "editor",

--- a/src/component/contents/DraftEditorTextNode.react.js
+++ b/src/component/contents/DraftEditorTextNode.react.js
@@ -26,7 +26,9 @@ const isElement = require('isElement');
  * would tries to remove the <br> tag, which may already been removed by Edge.
  * This causes the render to fail. Fall back to \n on Edge as well, for this reason.
  */
- const useNewlineChar = UserAgent.isBrowser('IE <= 11') || UserAgent.isBrowser('Edge');
+const useNewlineChar =
+  UserAgent.isBrowser('IE <= 11') ||
+  (UserAgent.isBrowser('Edge') && !UserAgent.isEngine('Blink'));
 
 /**
  * Check whether the node should be considered a newline.


### PR DESCRIPTION
## Problem

The cursor jumps around on X, when using CJK(Chinese, Japanese, Korean) IME.
user reports [ref](https://x.com/nanairopeace/status/1860041438333141289) [ref](https://x.com/nanairopeace/status/1865559427082023000)

To reproduce under Japanese IME.

1. "Enter" => create new line
2. "a" "a" => cursor jumps
3. "Enter" => mysterious duplicates
 
https://github.com/user-attachments/assets/69803854-613b-487a-8138-a377876e65c7

In the long run, we should migrate to [lexical](https://lexical.dev/)

## Cause

Edge browser used EdgeHTML engine and switch to Blink after 2020 [wiki](https://en.wikipedia.org/wiki/Microsoft_Edge )

In the year of 2018, This [PR](https://github.com/twitter-forks/draft-js/pull/8) fixed some issue on Edge which was related to newlines. This side effect caused the issue on Blink Edge from 2020, this is why the issue didn't reproduce on Chrome though Edge used the same browser engine.

Below is how it behaves after stricter check on Legacy Edge.


https://github.com/user-attachments/assets/8704d87a-11d2-450f-bc8d-9cd94fe0b3af




